### PR TITLE
Feat 18/click dataset

### DIFF
--- a/utils/click_dataset_loader.py
+++ b/utils/click_dataset_loader.py
@@ -108,9 +108,9 @@ def main(args):
 
     cnt["unsplitted"] = df.shape[0] - sum(cnt.values())
     cnt["total"] = df.shape[0]
-    summary = pd.DataFrame.from_dict(cnt, orient='index', columns=["count"])
-    print("**Summary of text split results**")
-    print(summary)
+    results = pd.DataFrame.from_dict(cnt, orient='index', columns=["count"])
+    print("**Results for text split**")
+    print(results)
 
     # group the data by id type / group = ["train", "augment", "remove"]
     ## ID tags for each training, augmentation
@@ -148,7 +148,12 @@ def main(args):
     ## slicing
     click_for_train = df.loc[idx_train]
     click_for_augment = df.loc[idx_augment]
-    print(f"\nSuccessfully grouped the click data into 'for_train', 'for_augment'")
+    cnt = {"For Training": click_for_train.shape[0], "For Augmentation": click_for_augment.shape[0]}
+    cnt["Removed"] = df.shape[0] - sum(cnt.values())
+    cnt["Total"] = df.shape[0]
+    results = pd.DataFrame.from_dict(cnt, orient='index', columns=["count"])
+    print("\n**Results for grouping by id type**")
+    print(results)
     
     ## saving
     click_for_train.to_csv(os.path.join(configs.data_dir, "click_for_train.csv"), index=False)


### PR DESCRIPTION
## Overview
- load the click dataset from huggingface datasets
- paragraph를 내포하는 question에 대해서 question과 paragraph로 split
- quesiton ID를 기준으로 훈련용, 증강용 데이터로 grouping

## Change Log
- formatting huggingface dataset into train.csv format
  - 문자열 형태의 answer를 choices 상의 index로 변환
- (가)~(다) 와 같은 특정 문장을 나타내는 기호가 중복되는 경우 제거
- 기타 text cleaning
- 정규표현식 기반으로 question+paragraph 형태의 question을 search & split
- ID type 기반으로 데이터를 훈련용, 증강용으로 구분 및 개별 저장

## To Reviewer
- 데이터 형태의 복잡성으로 인해 데이터 cleaning은 개별 행에 대한 처리로 진행

## Issue Tags
- Closed | Fixed: #18
- See also: #